### PR TITLE
Set default scheme and fix spacing

### DIFF
--- a/storage_influxdb.go
+++ b/storage_influxdb.go
@@ -111,18 +111,13 @@ func (i InfluxDBStorage) sendEvent(e Event) error {
 // NewInfluxDBStorage sets up a new InfluxDB storage backend
 func NewInfluxDBStorage(c *Config) InfluxDBStorage {
 	var err error
-	var scheme string
 	i := InfluxDBStorage{}
 
 	i.DBName = c.Storage.InfluxDB.Database
 	i.Namespace = c.Storage.InfluxDB.Namespace
 
-	if c.Storage.InfluxDB.Protocol != "udp" {
-		if c.Storage.InfluxDB.Scheme == "" {
-			scheme = "http"
-		} else {
-			scheme = c.Storage.InfluxDB.Scheme
-		}
+	if c.Storage.InfluxDB.Protocol != "udp" && c.Storage.InfluxDB.Scheme == "" {
+		c.Storage.InfluxDB.Scheme = "http"
 	}
 
 	switch c.Storage.InfluxDB.Protocol {


### PR DESCRIPTION
This sets a default scheme of `http` for InfluxDB storage if the scheme has not been specified and the protocol isn't `udp`.

Also added some blank lines to make the code more readable.