### PR TITLE
Small tweaks to aid clarity for logging defaults

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -111,8 +111,8 @@ The `storage` dictionary holds configuration for the various metrics storage and
 
 | Field Name | Description | 
 | ---------- | ----------- |
-| `metric`   | The format string used when logging metrics. Defaults to `%time %job %timing: %value (%tags)\n`.|
-| `event`    | The format string used when logging events. Defaults to `%time %name: %status (%tags)\n`.|
+| `metric`   | The format string used when logging metrics. Defaults to `%time [M: %job] %timing: %value (%tags)\n`.|
+| `event`    | The format string used when logging events. Defaults to `%time [E: %name] status: %status (%tags)\n`.|
 | `tags`     | The format string used to build a concatenated string of tags. Defaults to `%name: %value`.|
 | `tag-separator` | A string used to separate individual tags when building the `%tags` string. |
 

--- a/storage_log.go
+++ b/storage_log.go
@@ -164,10 +164,10 @@ func NewLogStorage(c *Config) (LogStorage, error) {
 		l.TimeFormat = "2006/01/02 15:04:05"
 	}
 	if l.Format.Metric == "" {
-		l.Format.Metric = "%time %job %timing: %value (%tags)\n"
+		l.Format.Metric = "%time [M: %job] %timing: %value (%tags)\n"
 	}
 	if l.Format.Event == "" {
-		l.Format.Event = "%time %name: %status (%tags)\n"
+		l.Format.Event = "%time [E: %name] status: %status (%tags)\n"
 	}
 	if l.Format.Tag == "" {
 		l.Format.Tag = "%name: %value"


### PR DESCRIPTION
Changes the default logging format strings to be more clear on the contents and whether its an event or a metric.

```
2020/06/10 17:14:16 [E: okta] status: 200 (crabby-location: Digitalocean SFO2, environment: prod, region: us-west-2, isp: amazon)
2020/06/10 17:14:16 [M: okta] dns_duration_milliseconds: 1.2881 (region: us-west-2, isp: amazon, crabby-location: Digitalocean SFO2, environment: prod)
2020/06/10 17:14:16 [M: okta] server_connection_duration_milliseconds: 31.28 (crabby-location: Digitalocean SFO2, environment: prod, region: us-west-2, isp: amazon)
2020/06/10 17:14:16 [M: okta] tls_handshake_duration_milliseconds: 41.8273 (region: us-west-2, isp: amazon, crabby-location: Digitalocean SFO2, environment: prod)
2020/06/10 17:14:16 [M: okta] server_processing_duration_milliseconds: 63.9011 (region: us-west-2, isp: amazon, crabby-location: Digitalocean SFO2, environment: prod)
2020/06/10 17:14:16 [M: okta] server_response_duration_milliseconds: 0.118772 (region: us-west-2, isp: amazon, crabby-location: Digitalocean SFO2, environment: prod)
2020/06/10 17:14:16 [M: okta] time_to_first_byte_milliseconds: 138.296 (environment: prod, region: us-west-2, isp: amazon, crabby-location: Digitalocean SFO2)
```