### PR TITLE
Headers and cookies support for simple check

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -23,7 +23,7 @@ Fields:
 | `url`      | The URL to probe. |
 | `method`   | The HTTP method to use. |
 | `interval` | How often crabby will initiate tests. (seconds) |
-| `headers`  | The headers that will be sent as part of the HTTP request. |
+| `header`   | The headers that will be sent as part of the HTTP request. |
 | `cookies`  | Cookies that will be sent as part of the HTTP request or set before the page loads (in selenium tests). This will override the `Cookie` header if set in `headers`. |
 
 ### `cookies`
@@ -169,6 +169,11 @@ jobs:
    type: selenium
    url:  https://mysite.org/some/page/
    interval: 30
+   headers:
+     Authorization: ["Bearer: myauthtoken"]
+     # This will add the header 'X-Custom-Header' twice to the request, once with value 'Header1'
+     # and again with value 'Header 2'
+     "X-Custom-Header": ["Header 1", "Header 2"]
    cookies:
     - name: auth
       domain: mysite.org

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -20,12 +20,16 @@ Fields:
 | ---------- | ----------- |
 | `name`     | The name of this test.  This will be used to name your Graphite/Datadog metrics |
 | `type`     | Type of test to conduct.  Can be `selenium` or `simple`. |
-| `url`      | The URL to probe.  Currently only HTTP GETs are supported. |
+| `url`      | The URL to probe. |
+| `method`   | The HTTP method to use. |
 | `interval` | How often crabby will initiate tests. (seconds) |
-| `cookies`  | Cookies that will be set before loading this page.  **This only works for `selenium` tests.** |
+| `headers`  | The headers that will be sent as part of the HTTP request. |
+| `cookies`  | Cookies that will be sent as part of the HTTP request or set before the page loads (in selenium tests). This will override the `Cookie` header if set in `headers`. |
 
 ### `cookies`
-The optional `cookies` array holds all cookies to be set for a given job.  **These only apply to `selenium` tests.**  These will be set before loading the page.  Please note that these will generate an additional hit to your site (a 404 URL, intentionally) to work around a Selenium security "feature" that doesn't allow you to set cookies for a site until the browser is already on that site.
+The optional `cookies` array holds all cookies to be sent as part of the HTTP request for a given job. 
+
+In selenium tests, these will be set before loading the page.  Please note that these will generate an additional hit to your site (a 404 URL, intentionally) to work around a Selenium security "feature" that doesn't allow you to set cookies for a site until the browser is already on that site.
 
 | Field Name | Description |
 | ---------- | ----------- |

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -170,10 +170,8 @@ jobs:
    url:  https://mysite.org/some/page/
    interval: 30
    headers:
-     Authorization: ["Bearer: myauthtoken"]
-     # This will add the header 'X-Custom-Header' twice to the request, once with value 'Header1'
-     # and again with value 'Header 2'
-     "X-Custom-Header": ["Header 1", "Header 2"]
+     Authorization: "Bearer: myauthtoken"
+     "X-Custom-Header": "Header 1"
    cookies:
     - name: auth
       domain: mysite.org

--- a/cookies.go
+++ b/cookies.go
@@ -1,6 +1,11 @@
 package main
 
-import selenium "sourcegraph.com/sourcegraph/go-selenium"
+import (
+	"net/http"
+	"strings"
+
+	selenium "sourcegraph.com/sourcegraph/go-selenium"
+)
 
 // Cookie holds cookie data specified in our job configuration that is
 // later translated into a selenium.Cookie for use in web requests
@@ -11,6 +16,22 @@ type Cookie struct {
 	Value  string `yaml:"value"`
 	Secure bool   `yaml:"secure,omitempty"`
 	Expiry uint   `yaml:"expiry,omitempty"`
+}
+
+// HeaderString returns the serialization of multiple cookies for use in a Cookie header
+func HeaderString(cookies []Cookie) string {
+	var sb strings.Builder
+	for _, c := range cookies {
+		// We're just going to re-use net/http's implementation of a Cookie, since
+		// proper validation and serialization of cookie names is very hairy.
+		httpCookie := http.Cookie{
+			Name:   c.Name,
+			Domain: c.Domain,
+		}
+		sb.WriteString(httpCookie.String())
+		sb.WriteString("; ")
+	}
+	return sb.String()
 }
 
 // AddCookies adds cookies to a webRequest in preparation for

--- a/cookies.go
+++ b/cookies.go
@@ -24,9 +24,11 @@ func HeaderString(cookies []Cookie) string {
 	for _, c := range cookies {
 		// We're just going to re-use net/http's implementation of a Cookie, since
 		// proper validation and serialization of cookie names is very hairy.
+
+		// In a Cookie header, we don't send any cookie metadata.
 		httpCookie := http.Cookie{
-			Name:   c.Name,
-			Domain: c.Domain,
+			Name:  c.Name,
+			Value: c.Value,
 		}
 		sb.WriteString(httpCookie.String())
 		sb.WriteString("; ")

--- a/jobs.go
+++ b/jobs.go
@@ -19,11 +19,11 @@ type Job struct {
 }
 
 type JobStep struct {
-	Name    string              `yaml:"name"`
-	URL     string              `yaml:"url"`
-	Method  string              `yaml:"method"`
-	Cookies []Cookie            `yaml:"cookies,omitempty"`
-	Header  map[string][]string `yaml:"header,omitempty"`
+	Name    string            `yaml:"name"`
+	URL     string            `yaml:"url"`
+	Method  string            `yaml:"method"`
+	Cookies []Cookie          `yaml:"cookies,omitempty"`
+	Header  map[string]string `yaml:"header,omitempty"`
 	// if header contains a different content type this overwrites it.
 	ContentType string            `yaml:"content-type,omitempty"`
 	Body        string            `yaml:"body,omitempty"`

--- a/simple.go
+++ b/simple.go
@@ -58,8 +58,10 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 		req.Header.Add(key, value)
 	}
 
-	// Add Cookie header
-	req.Header.Add("Cookie", HeaderString(j.Cookies))
+	if len(j.Cookies) > 0 {
+		// Add Cookie header
+		req.Header.Add("Cookie", HeaderString(j.Cookies))
+	}
 
 	var t0, t1, t2, t3, t4 time.Time
 

--- a/simple.go
+++ b/simple.go
@@ -54,10 +54,8 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 		return
 	}
 
-	for key, values := range j.Step.Header {
-		for _, value := range values {
-			req.Header.Add(key, value)
-		}
+	for key, value := range j.Step.Header {
+		req.Header.Add(key, value)
 	}
 
 	if len(j.Step.Cookies) > 0 {

--- a/simple.go
+++ b/simple.go
@@ -58,6 +58,9 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 		req.Header.Add(key, value)
 	}
 
+	// Add Cookie header
+	req.Header.Add("Cookie", HeaderString(j.Cookies))
+
 	var t0, t1, t2, t3, t4 time.Time
 
 	trace := &httptrace.ClientTrace{

--- a/simple.go
+++ b/simple.go
@@ -54,13 +54,15 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 		return
 	}
 
-	for key, value := range j.Headers {
-		req.Header.Add(key, value)
+	for key, values := range j.Step.Header {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 
-	if len(j.Cookies) > 0 {
+	if len(j.Step.Cookies) > 0 {
 		// Add Cookie header
-		req.Header.Add("Cookie", HeaderString(j.Cookies))
+		req.Header.Add("Cookie", HeaderString(j.Step.Cookies))
 	}
 
 	var t0, t1, t2, t3, t4 time.Time

--- a/simple.go
+++ b/simple.go
@@ -54,6 +54,10 @@ func RunSimpleTest(ctx context.Context, j Job, storage *Storage, client *http.Cl
 		return
 	}
 
+	for key, value := range j.Headers {
+		req.Header.Add(key, value)
+	}
+
 	var t0, t1, t2, t3, t4 time.Time
 
 	trace := &httptrace.ClientTrace{


### PR DESCRIPTION
Adds support for adding cookies and headers for `simple.go` check

Adds the following fields in jobs

* `header`: a string map of headers

Cookies are now serialized into a `Cookie` HTTP request header and passed along with the request. This overrides any `Cookie` header if it exists in the `headers` map.